### PR TITLE
Use binary mode to open the jsx script prior to copy over ftp.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -462,6 +462,15 @@ in your PATH.
 Revisions
 =========
 
+1.0.5
+-----
+
+Bug fixes
+'''''''''
+
+- Fixed ``indesign.save_as()`` in Python 3 where the jsx file was opened
+  in text mode instead of binary.
+
 1.0.3
 -----
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ else:
 
 setup(
     name="SimpleIDML",
-    version="1.0.4",
+    version="1.0.5",
     license='BSD Licence',
     author='Stanislas Guerra',
     author_email='stanislas.guerra@gmail.com',

--- a/src/simple_idml/__init__.py
+++ b/src/simple_idml/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-VERSION = "1.0.4"
+VERSION = "1.0.5"
 IdPkgNS = "http://ns.adobe.com/AdobeInDesign/idml/1.0/packaging"
 BACKINGSTORY = "XML/BackingStory.xml"
 

--- a/src/simple_idml/ftp.py
+++ b/src/simple_idml/ftp.py
@@ -26,7 +26,7 @@ def copy(src_filename, dst_filename, ftp_params=None, src_open_mode="rb"):
         try:
             if "b" in src_open_mode:
                 ftp.storbinary(command, f)
-            else:
+            else:  # python2 only. storlines in Python 3 requires binary mode as well.
                 ftp.storlines(command, f)
         except BaseException as e:
             print("Cannot STOR %s" % dst_filename)

--- a/src/simple_idml/indesign/indesign.py
+++ b/src/simple_idml/indesign/indesign.py
@@ -45,7 +45,7 @@ class InDesignSoapScript(object):
         self.javascript_server_copy_filename = self.server_path_mod.join(self.server_workdir,
                                                                          self.javascript_basename)
         ftp.copy(javascript_master_filename, self.javascript_client_copy_filename,
-                 self.ftp_params, src_open_mode="r")
+                 self.ftp_params, src_open_mode="rb")
 
     def set_params(self):
         self.params = self.client.factory.create("ns0:RunScriptParameters")


### PR DESCRIPTION
Bump version.